### PR TITLE
move dev dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reveni-js-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "reveni JS SDK",
   "main": "lib/index.js",
   "jest": {
@@ -39,21 +39,21 @@
     "@babel/cli": "^7.17.10",
     "@babel/core": "^7.18.5",
     "@babel/preset-env": "^7.18.2",
-    "@testing-library/dom": "^8.14.0",
-    "@testing-library/jest-dom": "^5.16.4",
     "babel-plugin-inline-dotenv": "^1.7.0",
     "babelrc-rollup": "^3.0.0",
     "core-js": "^3.21.1",
     "dotenv": "^16.0.1",
-    "husky": "^8.0.1",
-    "jest-environment-jsdom": "^28.1.1",
-    "lite-server": "^2.6.1",
-    "prettier": "^2.7.1",
     "rollup": "^2.75.7",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-dotenv": "^0.3.0"
   },
   "devDependencies": {
-    "jest": "^28.1.1"
+    "jest": "^28.1.1",
+    "@testing-library/dom": "^8.14.0",
+    "@testing-library/jest-dom": "^5.16.4",
+    "husky": "^8.0.1",
+    "jest-environment-jsdom": "^28.1.1",
+    "lite-server": "^2.6.1",
+    "prettier": "^2.7.1"
   }
 }


### PR DESCRIPTION
# Descripción

He movido las dependencias de desarrollo a dev dependencies. Las otras dependencias las dejo donde están ya que se utilizan en el postinstall para generar el bundle y el transpilado

# Checklist

- [ ] Está todo testeado :)
